### PR TITLE
Make 'Date of Passing' label consistent in all search filter forms

### DIFF
--- a/src/components/MainHeader/index.jsx
+++ b/src/components/MainHeader/index.jsx
@@ -580,7 +580,7 @@ class Masterhead extends Component {
                     </div>
                   </Toggler>
 
-                  <Toggler attr={{ title: 'Date of Death' }}>
+                  <Toggler attr={{ title: 'Date of Passing' }}>
                     <div className="toggler-con fx fields-3">
                       <div className="gr gr-1">
                         <h6>Month</h6>

--- a/src/containers/Search/index.jsx
+++ b/src/containers/Search/index.jsx
@@ -216,7 +216,7 @@ class Search extends Component {
                   </div>
                 </Toggler>
                 
-                <Toggler attr={{ title: 'Date of Passed Away', addClass: 'alt', 'isToggleDisabled': true }}>
+                <Toggler attr={{ title: 'Date of Passing', addClass: 'alt', 'isToggleDisabled': true }}>
                   <div className="toggler-con fx fields-3">
                     <div className="gr gr-1">
                       <h6>Month</h6>


### PR DESCRIPTION
Fix for Issue #10 

![image](https://user-images.githubusercontent.com/3946035/41760846-5adcc788-75c3-11e8-85ec-1493433f627c.png)

![image](https://user-images.githubusercontent.com/3946035/41760838-52812d86-75c3-11e8-9c72-9126337aff5e.png)

