### PR TITLE
Write Story limits text input characters to 255 to match server-side …

### DIFF
--- a/src/components/ProfileCard/index.jsx
+++ b/src/components/ProfileCard/index.jsx
@@ -7,6 +7,7 @@ import CommonService from "../../services/common";
 import ProfilePicture from '../ProfilePicture';
 import * as _ from 'lodash';
 import * as moment from 'moment';
+import * as forms from '../../constants/forms';
 
 class ProfileCard extends Component {
   constructor(props) {
@@ -14,6 +15,7 @@ class ProfileCard extends Component {
     
     this.togglePopup = this.togglePopup.bind(this);
     this.handleOutsideClick = this.handleOutsideClick.bind(this);
+    this.handleStoryContentInputChange = this.handleStoryContentInputChange.bind(this);
     this.hidePopup = this.hidePopup.bind(this);
     this.hideAllPopup = this.hideAllPopup.bind(this);
     this.toggleBadgeSelect = this.toggleBadgeSelect.bind(this);
@@ -96,6 +98,13 @@ class ProfileCard extends Component {
     }
     
     this.togglePopup(this.state.activePop)();
+  }
+
+  handleStoryContentInputChange(event) {
+    if (event.target.value.length > forms.CHARACTER_LIMIT_255) {
+      return;
+    }
+    this.setState({ storyContent: event.target.value });
   }
   
   // renderThumb
@@ -484,7 +493,9 @@ class ProfileCard extends Component {
                   <input type="text"
                          value={this.state.storyTitle}
                          onChange={event => this.setState({ storyTitle: event.target.value })}
-                         className="textctrl"/>
+                         className="textctrl"
+                         maxLength={forms.CHARACTER_LIMIT_255}
+                  />
                 </div>
               </div>
               <div className="fieldset">
@@ -492,8 +503,12 @@ class ProfileCard extends Component {
                 <div className="val">
                   <textarea className="textarea textctrl"
                             value={this.state.storyContent}
-                            onChange={event => this.setState({ storyContent: event.target.value })}
+                            onChange={event => this.handleStoryContentInputChange(event)}
+                            maxLength={forms.CHARACTER_LIMIT_255}
                   />
+                </div>
+                <div className="text-character-counter">
+                  {this.state.storyContent.length} / 255 characters remaining
                 </div>
               </div>
               <div className="actions fx">

--- a/src/components/ProfileCard/profile-card.scss
+++ b/src/components/ProfileCard/profile-card.scss
@@ -838,6 +838,13 @@
     height: 40px;
     line-height: 38px;
   }
+  .text-character-counter{
+    margin-top: 10px;
+
+    @include viewMd{
+      font-size: 14px;
+    }
+  }
 
   .dropzone{
     &.inline{
@@ -1161,4 +1168,3 @@
     padding-left: 38px;
   }
 }
-  

--- a/src/constants/forms.js
+++ b/src/constants/forms.js
@@ -1,0 +1,1 @@
+export const CHARACTER_LIMIT_255 = 255;


### PR DESCRIPTION
…validation.

Fixes #22 

Fix implemented using form field validation and counter. I decided to only add a counter to the "Message" field and not the "Title" field as well to keep the form cleaner. I did discover that the Title field also has a 255 character limit.

The error message was a database error that was propagating from va-online-memorial-data-models
to va-online-memorial-rest-api when it tries to create the model. You could add a separate card to improve that error message on the -rest-api project, but I personally think it's better to not display that message at all.

Video: https://www.screencast.com/t/0YQ9TkeqF4