### PR TITLE
Fix type prefix and grammar in the salute/share success messages.

### DIFF
--- a/src/components/Badges/index.jsx
+++ b/src/components/Badges/index.jsx
@@ -45,7 +45,7 @@ class Badges extends Component {
   salutePost() {
     APIService.salutePost(this.type, this.state.activeStory.id).then(() => {
       this.setState({ saluted: true });
-      CommonService.showSuccess("Story salute successfully");
+      CommonService.showSuccess(`${this.type} saluted successfully`);
     }).catch(err => CommonService.showError(err));
   }
 
@@ -55,7 +55,7 @@ class Badges extends Component {
   sharePost() {
     APIService.sharePost(this.type, this.state.activeStory.id).then(() => {
       this.setState({ saluted: true });
-      CommonService.showSuccess("Story salute successfully");
+      CommonService.showSuccess(`${this.type} shared successfully`);
     }).catch(err => CommonService.showError(err));
   }
 

--- a/src/components/Photos/index.jsx
+++ b/src/components/Photos/index.jsx
@@ -46,7 +46,7 @@ class Photos extends Component {
   salutePost() {
     APIService.salutePost(this.type, this.state.activePhoto.id).then(() => {
       this.setState({ saluted: true });
-      CommonService.showSuccess("Story salute successfully");
+      CommonService.showSuccess(`${this.type} saluted successfully`);
     }).catch(err => CommonService.showError(err));
   }
   
@@ -56,7 +56,7 @@ class Photos extends Component {
   sharePost() {
     APIService.sharePost(this.type, this.state.activePhoto.id).then(() => {
       this.setState({ saluted: true });
-      CommonService.showSuccess("Story salute successfully");
+      CommonService.showSuccess(`${this.type} shared successfully`);
     }).catch(err => CommonService.showError(err));
   }
   

--- a/src/components/Stories/index.jsx
+++ b/src/components/Stories/index.jsx
@@ -51,7 +51,7 @@ class Stories extends Component {
   salutePost() {
     APIService.salutePost(this.type, this.state.activeStory.id).then(() => {
       this.setState({ saluted: true });
-      CommonService.showSuccess("Story salute successfully");
+      CommonService.showSuccess(`${this.type} saluted successfully`);
     }).catch(err => CommonService.showError(err));
   }
   
@@ -61,7 +61,7 @@ class Stories extends Component {
   sharePost() {
     APIService.sharePost(this.type, this.state.activeStory.id).then(() => {
       this.setState({ saluted: true });
-      CommonService.showSuccess("Story salute successfully");
+      CommonService.showSuccess(`${this.type} shared successfully`);
     }).catch(err => CommonService.showError(err));
   }
   

--- a/src/components/Testimonials/index.jsx
+++ b/src/components/Testimonials/index.jsx
@@ -46,7 +46,7 @@ class Testimonials extends Component {
   salutePost() {
     APIService.salutePost(this.type, this.state.activeTest.id).then(() => {
       this.setState({ saluted: true });
-      CommonService.showSuccess("Story salute successfully");
+      CommonService.showSuccess(`${this.type} saluted successfully`);
     }).catch(err => CommonService.showError(err));
   }
   
@@ -56,7 +56,7 @@ class Testimonials extends Component {
   sharePost() {
     APIService.sharePost(this.type, this.state.activeTest.id).then(() => {
       this.setState({ saluted: true });
-      CommonService.showSuccess("Story salute successfully");
+      CommonService.showSuccess(`${this.type} shared successfully`);
     }).catch(err => CommonService.showError(err));
   }
   


### PR DESCRIPTION
Fixes #26 

Video: https://www.screencast.com/t/er1HzCb4MQw

Changed the grammar in order to create parallelism between the two actions. 
{Type} saluted successfully
{Type} shared successfully

There is a lot of code duplication in the Badges, Photos, Stories, and Testimonials which I will have to address when working on the "Blue overlay" section issues #15 #16 #17 #18 since I think they should be sharing common components since their presentation is identical.