### PR TITLE
Test for whitespace only caption as well as empty caption.

### DIFF
--- a/src/components/ProfileCard/index.jsx
+++ b/src/components/ProfileCard/index.jsx
@@ -266,10 +266,12 @@ class ProfileCard extends Component {
   onUploadPhoto() {
     const title = this.refs.photoCaption.value;
     const files = this.state.files;
+    const whiteSpaceOnlyRegExp = /^\s+$/;
+
     if (files.length <= 0) {
       return CommonService.showError("You at least need choose one photo.");
     }
-    if (_.isEmpty(title)) {
+    if (_.isEmpty(title) || whiteSpaceOnlyRegExp.test(title)) {
       return CommonService.showError("Photo caption should not be empty.");
     }
     


### PR DESCRIPTION
Fixes #33

lodash _.empty() returns true when there are only whitespace characters, so I added regular expression to check if the string is only whitespace.

I left _.empty() in there, though because if the field is null, it falls back to another generic error.

https://www.screencast.com/t/pVMRZf0g40

