### PR TITLE
'Reset Filter' button is too close to the footer

### DIFF
--- a/src/containers/Search/search.scss
+++ b/src/containers/Search/search.scss
@@ -172,7 +172,7 @@
     font-size: 20px;
     text-align: left;
     color: #0f73ba;
-    // margin-bottom: 10px;
+    margin-bottom: 10px;
 
     @include hover;
   }

--- a/src/containers/Search/search.scss
+++ b/src/containers/Search/search.scss
@@ -172,6 +172,7 @@
     font-size: 20px;
     text-align: left;
     color: #0f73ba;
+    // margin-bottom: 10px;
 
     @include hover;
   }


### PR DESCRIPTION
fixes #35 

reset filter link now 10px margin from footer 

![screen shot 2018-06-24 at 11 54 31 am](https://user-images.githubusercontent.com/21698552/41820811-6a6782fe-77a5-11e8-835a-5eb7cc663d06.png)
