### PR TITLE
'Salute' button icon is too close to the text

### DIFF
--- a/src/components/Badges/styles.scss
+++ b/src/components/Badges/styles.scss
@@ -1,7 +1,7 @@
 @import '../../styles/_mixins.scss';
 
 .btn-salute2 {
-  padding-left: 25px;
+  padding-left: 35px;
   background: #0f73ba url('../../i/star.png') 7px 10px no-repeat;
 
   &.disabled {


### PR DESCRIPTION
![screen shot 2018-06-24 at 12 41 23 pm](https://user-images.githubusercontent.com/21698552/41821376-81196a82-77ad-11e8-84a4-b1e8afcac577.png)

Salute text aligned properly within the button. 

The CSS for this button was in src/components/Badges/styles.scss. Which was unexpected for a Badges css to effect the buttons on other components.