### PR TITLE
Adjust Related Profiles flexbox settings so they don't go out of window

### DIFF
--- a/src/components/RelatedProfiles/styles.scss
+++ b/src/components/RelatedProfiles/styles.scss
@@ -4,6 +4,7 @@
 .profile-cards {
   .viewport {
     display: flex;
+    flex-flow: row wrap;
     justify-content: center;
   }
   h3 {
@@ -13,7 +14,8 @@
     padding: 68px 0;
   }
   .profile-card {
-    width: 392px;
+    flex-basis: 25%;
+    padding: 20px 30px;
     text-align: center;
 
     img {
@@ -56,8 +58,7 @@
       padding-bottom: 40px;
     }
     .profile-card {
-      margin-top: 30px;
-
+      flex-basis: 100%;
       &:first-child {
         margin-top: 0;
       }


### PR DESCRIPTION
Fixes #19 

https://www.screencast.com/t/Azot8msp

Set flex-basis to 25% so each related profile takes up a quarter of the flex row (since there can be up to 4 per row). Maintains the behavior of one per row in smaller screens/mobile devices.

Still looks terrible in tablet view, but that's due to the entire site's style using pixels instead of em/rem.