### PR TITLE
Make NOK proof download buttons work in user settings.

### DIFF
--- a/src/actions/dataAction.js
+++ b/src/actions/dataAction.js
@@ -438,7 +438,6 @@ function downloadFile(file) {
     API.downloadFile(file.fileURL).then(res => {
       const blob = new Blob([ res.response ], { type: file.mimeType });
       fileSaver.saveAs(blob, (file.name));
-      toast('file download success', { type: 'info' });
     });
   }
 }

--- a/src/components/SettingRequest/index.jsx
+++ b/src/components/SettingRequest/index.jsx
@@ -140,11 +140,13 @@ class SettingRequest extends React.Component{
                   <div className="submitted-proof">
                     <div className="proof-head">
                       <span>Submitted Proof</span>
-                      <a className="btn">Download</a>
                     </div>
                     {
                       get(s, 'proofs', []).map((p, j)=>(
-                        <div key={j} className="proof-item"><a onClick={() => this.downloadFile(p)}>{p.name}</a></div>
+                        <div key={j} className="proof-item">
+                          <a onClick={() => this.downloadFile(p)}>{p.name}</a>
+                          <a className="btn" onClick={() => this.downloadFile(p)}>Download</a>
+                        </div>
                       ))
                     }
                   </div>

--- a/src/components/SettingRequest/setting-request.scss
+++ b/src/components/SettingRequest/setting-request.scss
@@ -17,7 +17,7 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
-    @innclude fontSecondary;
+    @include fontSecondary;
   }
   .request-input{
     width: 100%;
@@ -143,6 +143,9 @@
       }
     }
     .proof-item{
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
       padding: 12px 0;
       font-size: 20px;
       border-bottom: 1px solid #000;
@@ -150,6 +153,10 @@
         color: #0f73ba;
         @include hover;
       }
+      .btn {
+        color: #ffffff !important;
+      }
+
     }
   }
   @include viewMd{


### PR DESCRIPTION
Fixes #65 

https://www.screencast.com/t/Ws6EjqVvGP

Download button had no event handler. Only the file name links worked, so I added the same event handler to the Download button and put the Download button in each row. There didn't appear to be a clean way to implement downloading all without modifying the server side code to actually zip and archive multiple files. Frontend implementation would have resorted to opening N number of save as dialogue boxes.

I also removed the "toast" for file download success because it was improperly implemented and would fire off every time you clicked on download whether or not you decided to save the file or cancel. There is a limitation in the file-saver library which is unable to detect if the user saves or cancels the download and the project maintainers recommend using the stream-saver library if that functionality is required: https://github.com/eligrey/FileSaver.js/issues/126
