### PR TITLE
Ensure user is logged off after deactivating account.

### DIFF
--- a/src/actions/auth.js
+++ b/src/actions/auth.js
@@ -61,16 +61,16 @@ function updateProfile(id, profile) {
   return function (dispatch) {
     API.updateProfile(id, profile).then(data => {
       dispatch(loadProfile(data));
-      toast('change saved success', { type: 'info' });
+      toast('Profile successfully updated.', { type: 'info' });
     });
   }
 }
 
 function deactivate() {
   return function (dispatch) {
-    API.deactivate().then(() => {
+    return API.deactivate().then(() => {
       dispatch(deactivateSuccess());
-      toast('deactivate success', { type: 'info' });
+      toast('Account was successfully deactivated.', { type: 'info' });
     });
   }
 }

--- a/src/components/SettingBasicDetails/index.jsx
+++ b/src/components/SettingBasicDetails/index.jsx
@@ -3,12 +3,17 @@ import PropTypes from 'prop-types';
 
 import Toggler from '../Toggler';
 import './setting-basic-details.scss';
+import { extend } from 'lodash';
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+import authAction from '../../actions/auth';
 
 class SettingBasicDetails extends Component{
   constructor(props){
     super(props);
     this.state={
       details: props.details,
+      redirectTo: null,
     };
     this.updateBaseProfile = this.updateBaseProfile.bind(this);
     this.deactivateAccount = this.deactivateAccount.bind(this);
@@ -42,7 +47,9 @@ class SettingBasicDetails extends Component{
   }
 
   deactivateAccount() {
-    this.props.deactivate();
+    this.props.deactivate().then(() => {
+      this.props.authAction.logout();
+    });
   }
 
   render(){
@@ -50,7 +57,6 @@ class SettingBasicDetails extends Component{
     const {faqs} = this.props;
     return (
       <div className="setting-basic-details">
-        <h2 className="basic-details-title">Basic Details</h2>
         <div className="basic-details-row">
           <div className="basic-details-col-1">
             <div className="basic-details-label">Username</div>
@@ -124,4 +130,16 @@ SettingBasicDetails.props={
   }))
 };
 
-export default SettingBasicDetails;
+const mapStateToProps = (state) => {
+  return {
+    ui: state.ui
+  }
+};
+
+const matchDispatchToProps = (dispatch) => {
+  return {
+    authAction: bindActionCreators(extend({}, authAction), dispatch),
+  };
+};
+
+export default connect(mapStateToProps, matchDispatchToProps)(SettingBasicDetails);

--- a/src/containers/Setting/index.jsx
+++ b/src/containers/Setting/index.jsx
@@ -82,7 +82,7 @@ class Setting extends Component {
    * deactive account
    */
   deactivate() {
-    this.props.actions.deactivate();
+    return this.props.actions.deactivate();
   }
 
   /**


### PR DESCRIPTION
Fixes #67 

https://www.screencast.com/t/cdarp9Th

Ensures that clicking on the deactivate button makes API call to deactivate account, clears the currently logged in session, and redirects to the root page.

This fix is dependent on https://github.com/topcoderinc/va-online-memorial-rest-api/pull/3
since the log in authentication process does not even check the account's status before allowing the user to log in.

Note that there is currently no process for reactivating an account if that was desired.