### PR TITLE
Add padding to the left and right sides of search result table cells.

### DIFF
--- a/src/components/SearchTable/styles.scss
+++ b/src/components/SearchTable/styles.scss
@@ -81,6 +81,7 @@
         font-size: 20px;
       }
       td{
+        padding: 0 10px;
         height: 85px;
         .user{
           padding-left: 76px;


### PR DESCRIPTION
Fixes #49 

![image](https://user-images.githubusercontent.com/3946035/42103711-daae077c-7b97-11e8-8751-b149abcdf148.png)
