### PR TITLE
Point the NOK decline button to the correct action. Use a placeholder…

### DIFF
--- a/src/actions/dataAction.js
+++ b/src/actions/dataAction.js
@@ -374,9 +374,9 @@ function approveRequest(id) {
  * @param id request id
  * @returns {Function}
  */
-function declineRequest(id) {
+function declineRequest(id, reasonForDecline) {
   return function (dispatch) {
-    API.declineRequest(id).then(() => {
+    API.declineRequest(id, reasonForDecline).then(() => {
       updateRequest(dispatch);
       toast('decline success', { type: 'info' });
     });

--- a/src/components/AdminRequest/index.jsx
+++ b/src/components/AdminRequest/index.jsx
@@ -5,6 +5,10 @@ import { NavLink } from 'react-router-dom';
 
 import './admin-request.scss';
 
+// The API requires a reason the Request was declined that is recorded on the NextOfKin
+// model. This is a placeholder until the spec for a form/interface is created for this.
+const ReasonForDeclinePlaceholder = 'Declined by Admin';
+
 const AdminRequest = ({title, requests, archived, downloadFile, decline, approve })=>(
   <div className="admin-request">
     <h2 className="admin-request-title">{title}</h2>
@@ -48,7 +52,7 @@ const AdminRequest = ({title, requests, archived, downloadFile, decline, approve
                   <span className="hide-md">Email Post Creator</span>
                   <span className="show-md">Email Creator</span>
                 </a>
-                <a className="btn" onClick={() => decline(item.id)}>Decline</a>
+                <a className="btn" onClick={() => decline(item.id, ReasonForDeclinePlaceholder)}>Decline</a>
                 <a className="btn" onClick={() => approve(item.id)}>Approve</a>
               </div>
             }

--- a/src/containers/Setting/index.jsx
+++ b/src/containers/Setting/index.jsx
@@ -144,9 +144,10 @@ class Setting extends Component {
   /**
    * decline request by id
    * @param id the post id
+   * @param reasonForDecline the string recorded for why the NOK request was declined
    */
-  declineRequest(id) {
-    this.props.dataAction.deleteNOKRequest(id);
+  declineRequest(id, reasonForDecline) {
+    this.props.dataAction.declineRequest(id, reasonForDecline);
   }
 
   /**

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -430,10 +430,11 @@ export default class APIService {
    * decline NOK request by id
    * @param id
    */
-  static declineRequest(id) {
+  static declineRequest(id, reasonForDecline) {
     return request
-      .put(`${FALLBACK_API_URL}/v1/nextOfKins/${id}/decline`)
+      .put(`${FALLBACK_API_URL}/v1/nextOfKins/${id}/reject`)
       .set('Authorization', `Bearer ${AuthService.getAccessToken()}`)
+      .send({ response: reasonForDecline })
       .use(errorRedirect)
       .use(CommonService.progressInterceptor)
       .end()


### PR DESCRIPTION
… reason for decline to conform to API.

Fixes #46 

https://www.screencast.com/t/d41itNovwV

Decline button was using the wrong action (deleteNOKRequest which appears to be used for when a user deletes his/her own request, not for admins). The other thing I discovered was that the API requires a key called "response" in the request body, which is the reason the request is declined.

I think there should be an issue to spec out the form for reason it was declined (it could be a text field the admin types into or multiple options) serialized into a string for storage in the DB. So when user clicks on Decline, modal form appears, and then the user needs to submit form.